### PR TITLE
Enhance log entries with k8s pod labels using fluent-plugin-kubernetes_metadata_filter.

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -311,7 +311,7 @@ data:
       # Interval in seconds to dump cache stats locally in the Fluentd log.
       stats_interval 300
       # TTL in seconds of each cached element.
-      cache_ttl 5
+      cache_ttl 30
     </filter>
 
     <filter reform.**>
@@ -324,7 +324,7 @@ data:
         # "logging.googleapis.com/labels". Prefix these labels with
         # "k8s-pod-labels" to distinguish with other labels and avoid
         # label name collision with other types of labels.
-        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-labels/#{k}", v]}.to_h; end; nil}
+        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-label/#{k}", v]}.to_h; end; nil}
       </record>
       # Delete this dummy field and the rest of "kubernetes" and "docker".
       remove_keys _dummy_,kubernetes,docker

--- a/agents.yaml
+++ b/agents.yaml
@@ -156,7 +156,7 @@ spec:
             configMapKeyRef:
               name: cluster-config
               key: cluster_location
-        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:0.8-1.6.2-1
+        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -197,6 +197,8 @@ spec:
           name: config-volume
         - mountPath: /etc/google-cloud/
           name: google-cloud-config
+      serviceAccount: logging-agent
+      serviceAccountName: logging-agent
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -299,6 +301,33 @@ data:
       suppress_parse_error_log true
       emit_invalid_record_to_error false
       key_name log
+    </filter>
+
+    <filter reform.**>
+      # This plugin uses environment variables KUBERNETES_SERVICE_HOST and
+      # KUBERNETES_SERVICE_PORT to talk to the API server. These environment
+      # variables are added by kubelet automatically.
+      @type kubernetes_metadata
+      # Interval in seconds to dump cache stats locally in the Fluentd log.
+      stats_interval 300
+      # TTL in seconds of each cached element.
+      cache_ttl 5
+    </filter>
+
+    <filter reform.**>
+      # We have to use record_modifier because only this plugin supports complex
+      # logic to modify record the way we need.
+      @type record_modifier
+      enable_ruby true
+      <record>
+        # Extract "kubernetes"->"labels" and set them as
+        # "logging.googleapis.com/labels". Prefix these labels with
+        # "k8s-pod-labels" to distinguish with other labels and avoid
+        # label name collision with other types of labels.
+        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-labels/#{k}", v]}.to_h; end; nil}
+      </record>
+      # Delete this dummy field and the rest of "kubernetes" and "docker".
+      remove_keys _dummy_,kubernetes,docker
     </filter>
 
     <match reform.**>

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -191,7 +191,7 @@ data:
       # Interval in seconds to dump cache stats locally in the Fluentd log.
       stats_interval 300
       # TTL in seconds of each cached element.
-      cache_ttl 5
+      cache_ttl 30
     </filter>
 
     <filter reform.**>
@@ -204,7 +204,7 @@ data:
         # "logging.googleapis.com/labels". Prefix these labels with
         # "k8s-pod-labels" to distinguish with other labels and avoid
         # label name collision with other types of labels.
-        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-labels/#{k}", v]}.to_h; end; nil}
+        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-label/#{k}", v]}.to_h; end; nil}
       </record>
       # Delete this dummy field and the rest of "kubernetes" and "docker".
       remove_keys _dummy_,kubernetes,docker

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -36,7 +36,7 @@ spec:
             configMapKeyRef:
               name: cluster-config
               key: cluster_location
-        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:0.8-1.6.2-1
+        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -77,6 +77,8 @@ spec:
           name: config-volume
         - mountPath: /etc/google-cloud/
           name: google-cloud-config
+      serviceAccount: logging-agent
+      serviceAccountName: logging-agent
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -179,6 +181,33 @@ data:
       suppress_parse_error_log true
       emit_invalid_record_to_error false
       key_name log
+    </filter>
+
+    <filter reform.**>
+      # This plugin uses environment variables KUBERNETES_SERVICE_HOST and
+      # KUBERNETES_SERVICE_PORT to talk to the API server. These environment
+      # variables are added by kubelet automatically.
+      @type kubernetes_metadata
+      # Interval in seconds to dump cache stats locally in the Fluentd log.
+      stats_interval 300
+      # TTL in seconds of each cached element.
+      cache_ttl 5
+    </filter>
+
+    <filter reform.**>
+      # We have to use record_modifier because only this plugin supports complex
+      # logic to modify record the way we need.
+      @type record_modifier
+      enable_ruby true
+      <record>
+        # Extract "kubernetes"->"labels" and set them as
+        # "logging.googleapis.com/labels". Prefix these labels with
+        # "k8s-pod-labels" to distinguish with other labels and avoid
+        # label name collision with other types of labels.
+        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod-labels/#{k}", v]}.to_h; end; nil}
+      </record>
+      # Delete this dummy field and the rest of "kubernetes" and "docker".
+      remove_keys _dummy_,kubernetes,docker
     </filter>
 
     <match reform.**>

--- a/rbac-setup.yaml
+++ b/rbac-setup.yaml
@@ -64,6 +64,45 @@ subjects:
   name: metadata-agent
   namespace: stackdriver-agents
 ---
+# Service account for Logging Agent.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logging-agent
+  namespace: stackdriver-agents
+---
+# ClusterRole with permissions required by Logging Agent
+# filter_kubernetes_metadata plugin.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: stackdriver-user:logging-agent
+  namespace: stackdriver-agents
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - watch
+  - get
+  - list
+---
+# ClusterRoleBinding for Logging Agent.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackdriver-user:logging-agent
+  namespace: stackdriver-agents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: stackdriver-user:logging-agent
+subjects:
+- kind: ServiceAccount
+  name: logging-agent
+  namespace: stackdriver-agents
+---
 # Service account for Heapster.
 apiVersion: v1
 kind: ServiceAccount

--- a/rbac-setup.yaml
+++ b/rbac-setup.yaml
@@ -80,7 +80,7 @@ metadata:
   namespace: stackdriver-agents
 rules:
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - pods
   verbs:

--- a/rbac-setup.yaml
+++ b/rbac-setup.yaml
@@ -82,7 +82,7 @@ rules:
 - apiGroups:
   - '*'
   resources:
-  - '*'
+  - pods
   verbs:
   - watch
   - get


### PR DESCRIPTION
1. Add the filter_kubernetes_metadata plugin which enriches the log entry with additional "kubernetes" and "docker" fields.
2. Use a record_modifier plugin to reformat the log entry, extract these pod labels from "kubernetes"->"labels" and set them as "logging.googleapis.com/labels" with prefix "k8s-pod-labels/". Removed the "kubernetes" and "docker" fields.