### PR TITLE
Add namespaces permission for kubernetes_metadata filter plugin.

### DIFF
--- a/rbac-setup.yaml
+++ b/rbac-setup.yaml
@@ -83,6 +83,7 @@ rules:
   - ""
   resources:
   - pods
+  - namespaces
   verbs:
   - watch
   - get


### PR DESCRIPTION
This is to fix:

```
[error]: config error file="/etc/google-fluentd/google-fluentd.conf" error_class=Fluent::ConfigError error="start_namespace_watch: Exception encountered setting up namespace watch from Kubernetes API v1 endpoint https://10.75.240.1:443/api: namespaces is forbidden: User \"system:serviceaccount:stackdriver-agents:logging-agent\" cannot list namespaces at the cluster scope ({\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"namespaces is forbidden: User \\\"system:serviceaccount:stackdriver-agents:logging-agent\\\" cannot list namespaces at the cluster scope\",\"reason\":\"Forbidden\",\"details\":{\"kind\":\"namespaces\"},\"code\":403}\n)"
```