### PR TITLE
Split ConfigMap into two to overwrite the original google-fluentd.conf file.

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -195,8 +195,11 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
+        - mountPath: /etc/google-fluentd/google-fluentd.conf
+          subPath: google-fluentd.conf
+          name: output-config-volume
         - mountPath: /etc/google-fluentd/config.d
-          name: config-volume
+          name: input-config-volume
         - mountPath: /etc/google-cloud/
           name: google-cloud-config
       serviceAccount: logging-agent
@@ -225,8 +228,12 @@ spec:
         name: varlibdockercontainers
       - configMap:
           defaultMode: 420
-          name: logging-agent-config
-        name: config-volume
+          name: logging-agent-output-config
+        name: output-config-volume
+      - configMap:
+          defaultMode: 420
+          name: logging-agent-input-config
+        name: input-config-volume
       - configMap:
           defaultMode: 420
           name: google-cloud-config
@@ -236,7 +243,12 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
 ---
+# Config map for Logging Agent input and corresponding filter plugins.
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging-agent-input-config
+  namespace: stackdriver-agents
 data:
   containers.input.conf: |-
     # This configuration file for Fluentd is used
@@ -611,7 +623,15 @@ data:
         process_start_timestamp ${record["process_start_timestamp"].to_i}
       </record>
     </filter>
-  output.conf: |-
+---
+# Config map for Logging Agent output and corresponding filter plugins.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging-agent-output-config
+  namespace: stackdriver-agents
+data:
+  google-fluentd.conf: |-
     # This match is placed before the all-matching output to provide metric
     # exporter with a process start timestamp for correct exporting of
     # cumulative metrics to Stackdriver.
@@ -755,10 +775,6 @@ data:
       k8s_cluster_location "#{ENV["CLUSTER_LOCATION"]}"
       adjust_invalid_timestamps false
     </match>
-kind: ConfigMap
-metadata:
-  name: logging-agent-config
-  namespace: stackdriver-agents
 
 ---
 apiVersion: extensions/v1beta1

--- a/agents.yaml
+++ b/agents.yaml
@@ -632,6 +632,8 @@ metadata:
   namespace: stackdriver-agents
 data:
   google-fluentd.conf: |-
+    @include config.d/*.conf
+
     # This match is placed before the all-matching output to provide metric
     # exporter with a process start timestamp for correct exporting of
     # cumulative metrics to Stackdriver.

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -512,6 +512,8 @@ metadata:
   namespace: stackdriver-agents
 data:
   google-fluentd.conf: |-
+    @include config.d/*.conf
+
     # This match is placed before the all-matching output to provide metric
     # exporter with a process start timestamp for correct exporting of
     # cumulative metrics to Stackdriver.

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -75,8 +75,11 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
+        - mountPath: /etc/google-fluentd/google-fluentd.conf
+          subPath: google-fluentd.conf
+          name: output-config-volume
         - mountPath: /etc/google-fluentd/config.d
-          name: config-volume
+          name: input-config-volume
         - mountPath: /etc/google-cloud/
           name: google-cloud-config
       serviceAccount: logging-agent
@@ -105,8 +108,12 @@ spec:
         name: varlibdockercontainers
       - configMap:
           defaultMode: 420
-          name: logging-agent-config
-        name: config-volume
+          name: logging-agent-output-config
+        name: output-config-volume
+      - configMap:
+          defaultMode: 420
+          name: logging-agent-input-config
+        name: input-config-volume
       - configMap:
           defaultMode: 420
           name: google-cloud-config
@@ -116,7 +123,12 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
 ---
+# Config map for Logging Agent input and corresponding filter plugins.
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging-agent-input-config
+  namespace: stackdriver-agents
 data:
   containers.input.conf: |-
     # This configuration file for Fluentd is used
@@ -491,7 +503,15 @@ data:
         process_start_timestamp ${record["process_start_timestamp"].to_i}
       </record>
     </filter>
-  output.conf: |-
+---
+# Config map for Logging Agent output and corresponding filter plugins.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging-agent-output-config
+  namespace: stackdriver-agents
+data:
+  google-fluentd.conf: |-
     # This match is placed before the all-matching output to provide metric
     # exporter with a process start timestamp for correct exporting of
     # cumulative metrics to Stackdriver.
@@ -635,7 +655,3 @@ data:
       k8s_cluster_location "#{ENV["CLUSTER_LOCATION"]}"
       adjust_invalid_timestamps false
     </match>
-kind: ConfigMap
-metadata:
-  name: logging-agent-config
-  namespace: stackdriver-agents


### PR DESCRIPTION
This is to reduce the stale num_threads in order to decrease memory usage.

Initial testing seems to be quite promising:
![image](https://user-images.githubusercontent.com/5287526/63184853-5c386200-c026-11e9-8f43-a787300eaa73.png)

Will monitor it for a few hours before merging.