### PR TITLE
Set the memory limit to 200MB

### DIFF
--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -61,7 +61,7 @@ spec:
         resources:
           limits:
             cpu: "1"
-            memory: 500Mi
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 200Mi


### PR DESCRIPTION
Two reasons why this is OK:
- We have improved memory usage: https://github.com/GoogleCloudPlatform/google-fluentd/pull/197
- This seems to be right for workloads that heavily use the page cache, but don't necessarily benefit from it: https://github.com/kubernetes/kubernetes/issues/43916#issuecomment-393228487

@davidbtucker you were selected as the reviewer by the pRNG.