### PR TITLE
Set Logging Agent memory limit to 300 MiB in regression cluster to better observe the behavior when the memory usage exceeds expectation.

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -186,7 +186,7 @@ spec:
         resources:
           limits:
             cpu: "1"
-            memory: 200Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 200Mi

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: "1"
-            memory: 200Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 200Mi


### PR DESCRIPTION
The actual checks to verify that whether 200 MiB limit is hit will be in the canary analysis.