### PR TITLE
Update extensions/v1beta1 to apps/v1 for GKE 1.16 compatibility.

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS AUTO-GENERATED DO NOT EDIT
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -118,7 +118,7 @@ spec:
         name: google-cloud-config
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -908,7 +908,7 @@ data:
     @include config.d/*.conf
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/heapster.yaml
+++ b/heapster.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/logging-agent.yaml
+++ b/logging-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/metadata-agent.yaml
+++ b/metadata-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
GKE 1.16 release no longer serves DaemonSet and Deployment in the extensions/v1beta1 API version (see [release notes](See https://cloud.google.com/kubernetes-engine/docs/release-notes)). 

Was seeing this error in build with GKE 1.16.8-gke.9:

```
+ kubectl apply -f /tmpfs/src/gfile/agents.yaml
configmap/logging-agent-input-config created
configmap/logging-agent-output-config created
unable to recognize "/tmpfs/src/gfile/agents.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
unable to recognize "/tmpfs/src/gfile/agents.yaml": no matches for kind "DaemonSet" in version "extensions/v1beta1"
unable to recognize "/tmpfs/src/gfile/agents.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
```

After update with this PR, was able to build with GKE 1.16.8-gke.9 successfully:

```
+ kubectl apply -f https://raw.githubusercontent.com/Stackdriver/kubernetes-configs/jschulz-gke116-update/agents.yaml
deployment.apps/heapster created
daemonset.apps/stackdriver-logging-agent created
configmap/logging-agent-input-config created
configmap/logging-agent-output-config created
deployment.apps/stackdriver-metadata-agent-cluster-level created
```

